### PR TITLE
Handle invalid JSON from codeclimate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,16 @@ export default {
           cwd: dirname(configurationFilePath),
         };
         const result = await Helpers.exec('/bin/bash', execArgs, execOpts);
-        const messages = JSON.parse(result);
+        let messages;
+        try {
+          messages = JSON.parse(result);
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error(
+            'Invalid JSON returned from codeclimate, error and output attached.',
+            e, result);
+          return [];
+        }
         const linterResults = [];
         let range;
         Object.keys(messages).forEach((issueKey) => {


### PR DESCRIPTION
When codeclimate gives us something back that can't be parsed as valid JSON report it to the users console.

Fixes #41.