### PR TITLE
Check for a non-existant .git directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,15 @@ export default {
         // want one, and says no, we won't bug them again.
         const configurationFilePath = await Helpers.findAsync(fileDir, configurationFile);
         if (configurationFilePath === null) {
-          const gitDir = dirname(await Helpers.findAsync(fileDir, '.git'));
+          const gitPath = await Helpers.findAsync(fileDir, '.git');
+          let gitDir;
+          if (gitPath !== null) {
+            gitDir = dirname(gitPath);
+          } else {
+            // Fall back to the directory of the current file if a .git repo
+            // can't be found.
+            gitDir = dirname(filePath);
+          }
 
           if (atom.config.get('linter-codeclimate.init') !== false) {
             const message = 'No .codeclimate.yml file found. Should I ' +


### PR DESCRIPTION
Check whether a `.git` directory was actually found before attempting to use it. If one isn't found, fall back to the directory of the current
file.

Fixes #55.