### PR TITLE
Utilize uniqueKey for exec, fix measure bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,12 @@ const getEnabledEngines = (configFilePath) => {
 const badCommands = new Set();
 
 const startMeasure = (baseName) => {
-  performance.mark(`${baseName}-start`);
+  const startMark = `${baseName}-start`;
+  // Clear start mark from previous execution for the same file
+  if (performance.getEntriesByName(startMark).length) {
+    performance.clearMarks(startMark);
+  }
+  performance.mark(startMark);
 };
 
 const endMeasure = (baseName) => {
@@ -202,6 +207,7 @@ export default {
           [relpath, '</dev/null']);
         const execOpts = {
           cwd: dirname(configurationFilePath),
+          uniqueKey: `linter-codeclimate::${relpath}`,
         };
         if (this.disableTimeout) {
           execOpts.timeout = Infinity;
@@ -215,7 +221,8 @@ export default {
         }
 
         // Start measure for how long the analysis took.
-        startMeasure('linter-codeclimate: Analysis');
+        const measureId = `linter-codeclimate: \`${relpath}\` analysis`;
+        startMeasure(measureId);
 
         // Execute the Code Climate CLI, parse the results, and emit them to the
         // Linter package as warnings. The Linter package handles the styling.
@@ -226,6 +233,12 @@ export default {
           notifyError(e, `${this.executablePath} ${execArgs.join(' ')}`);
           return null;
         }
+
+        // Handle unique spawning: killed execs will return null
+        if (result === null) {
+          return null;
+        }
+
         let messages;
         try {
           messages = JSON.parse(result);
@@ -276,7 +289,7 @@ export default {
         });
 
         // Log the length of time it took to run analysis
-        endMeasure('linter-codeclimate: Analysis');
+        endMeasure(measureId);
         return linterResults;
       },
     };


### PR DESCRIPTION
This PR fixes next issues:

- Multiple CodeClimate executions for the same source file (through the option `uniqueKey`): now there is only one execution running for a given source file (which improves performance and saves device resources). For heavy executions, 
- Set performance marks based upon the source file's relative path, which allows measuring correctly the concurrent linting of different source files.

Fixes #62.