### PR TITLE
Fix duplicated issues and upgrade to linter v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,11 +32,16 @@ const endMeasure = (baseName) => {
     performance.mark(`${baseName}-end`);
     performance.measure(baseName, `${baseName}-start`, `${baseName}-end`);
     // eslint-disable-next-line no-console
-    console.log(`${baseName} took: `, performance.getEntriesByName(baseName)[0].duration);
+    console.log(`${baseName} took: ${performance.getEntriesByName(baseName)[0].duration}`);
     performance.clearMarks(`${baseName}-end`);
     performance.clearMeasures(baseName);
   }
   performance.clearMarks(`${baseName}-start`);
+};
+
+const mapSeverity = {
+  major: 'error',
+  minor: 'warning',
 };
 
 /**
@@ -91,6 +96,18 @@ const notifyError = (err, cmd, description = '', extraDetails = '', buttons = []
 
 export default {
   activate() {
+    // Idle callback to check version
+    this.idleCallbacks = new Set();
+    let depsCallbackID;
+    const installLinterCodeclimateDeps = () => {
+      this.idleCallbacks.delete(depsCallbackID);
+      if (!atom.inSpecMode()) {
+        require('atom-package-deps').install('linter-codeclimate');
+      }
+    };
+    depsCallbackID = window.requestIdleCallback(installLinterCodeclimateDeps);
+    this.idleCallbacks.add(depsCallbackID);
+
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe(
       'linter-codeclimate.executablePath', (value) => {
@@ -110,6 +127,8 @@ export default {
   },
 
   deactivate() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    this.idleCallbacks.clear();
     this.subscriptions.dispose();
   },
 
@@ -133,6 +152,7 @@ export default {
       name: 'Code Climate',
       grammarScopes: ['*'],
       scope: 'file',
+      lintsOnChange: false,
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
         const fileDir = dirname(filePath);
@@ -237,6 +257,7 @@ export default {
           return [];
         }
         const linterResults = [];
+        const fingerprints = new Set();
         let range;
         Object.keys(messages).forEach((issueKey) => {
           const issue = messages[issueKey];
@@ -267,11 +288,21 @@ export default {
             range = Helpers.generateRange(textEditor, line);
           }
 
+          // Avoid duplicated issues
+          // TODO Remove when https://github.com/phpmd/phpmd/issues/467 fixed
+          if (fingerprints.has(issue.fingerprint)) {
+            return;
+          }
+          fingerprints.add(issue.fingerprint);
+
           linterResults.push({
-            type: 'Warning',
-            text: issue.description,
-            filePath,
-            range,
+            severity: mapSeverity[issue.severity] || 'warning',
+            excerpt: `${issue.engine_name.toUpperCase()}: ${issue.description} [${issue.check_name}]`,
+            description: (issue.content && issue.content.body) ? issue.content.body : undefined,
+            location: {
+              file: filePath,
+              position: range,
+            },
           });
         });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/AtomLinter/linter-codeclimate",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.4.0 <2.0.0"
+    "atom": ">=1.7.0 <2.0.0"
   },
   "configSchema": {
     "executablePath": {
@@ -30,16 +30,20 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "js-yaml": "^3.5.3",
-    "fs-plus": "^3.0.0"
+    "atom-package-deps": "^4.6.0",
+    "fs-plus": "^3.0.0",
+    "js-yaml": "^3.5.3"
   },
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },
+  "package-deps": [
+    "linter:2.0.0"
+  ],
   "devDependencies": {
     "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^11.1.1",

--- a/spec/linter-codeclimate-spec.js
+++ b/spec/linter-codeclimate-spec.js
@@ -23,14 +23,18 @@ describe('The codeclimate provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(coolCodePath).then(editor => lint(editor)).then(
         (messages) => {
-          expect(messages[0].type).toBe('Warning');
-          expect(messages[0].text).toBe('Unused method argument - `bar`. If ' +
-            "it's necessary, use `_` or `_bar` as an argument name to indicate " +
-            "that it won't be used. You can also write as `foo(*)` if you want " +
-            "the method to accept any arguments but don't care about them.");
-          expect(messages[0].html).not.toBeDefined();
-          expect(messages[0].filePath).toBe(coolCodePath);
-          expect(messages[0].range).toEqual([[1, 11], [1, 14]]);
+          expect(messages[0].severity).toBe('warning');
+          expect(messages[0].excerpt).toBe('RUBOCOP: Unused method argument - ' +
+            "`bar`. If it's necessary, use `_` or `_bar` as an argument name to " +
+            "indicate that it won't be used. You can also write as `foo(*)` if " +
+            "you want the method to accept any arguments but don't care about " +
+            'them. [Rubocop/Lint/UnusedMethodArgument]');
+          expect(messages[0].description).toBeDefined();
+          expect(messages[0].reference).not.toBeDefined();
+          expect(messages[0].icon).not.toBeDefined();
+          expect(messages[0].solutions).not.toBeDefined();
+          expect(messages[0].location.file).toBe(coolCodePath);
+          expect(messages[0].location.position).toEqual([[1, 11], [1, 14]]);
         },
       ),
     ),


### PR DESCRIPTION
I'm using this package to lint PHP files. The result from command line for a given file is:

```shell
Starting analysis
Running phpmd: Done!

== functions.php (7 issues) ==
20-36: The variable $parent_style is not named in camelCase. [phpmd]
20-36: The variable $parent_style is not named in camelCase. [phpmd]
20-36: The variable $parent_style is not named in camelCase. [phpmd]
33-35: The method cge_cgesite_theme_enqueue_styles uses an else expression. Else is never necessary and you can simplify the code to work without else. [phpmd]
37-47: The variable $parent_style is not named in camelCase. [phpmd]
37-47: The variable $parent_style is not named in camelCase. [phpmd]
37-47: The variable $parent_style is not named in camelCase. [phpmd]

Analysis complete! Found 7 issues.
```

As you can see, there are repeated issues. The problem is that when clicking on the linter badges to show the errors/warnings, I get the following warnings in the console, due to the repeated issues returned by CodeClimate.

![captura de pantalla de 2017-04-19 15-35-53](https://cloud.githubusercontent.com/assets/10707639/25190312/1f0f6f5a-252c-11e7-8241-4440e0ae8d1e.png)

Besides, there are really less issues that shown in the badges. I see no benefit from getting the linter queue populated with repeated errors. That's one of the goals of this PR: removing repeated errors.

Also, I would like to distinguish the severity of the returned issues instead tagging them as `Warning`s by default. The severity of the issues is [a feature introduced past month](https://codeclimate.com/changelog/58c176e4f64b5d027b000858), and I think it would be a desirable and beneficial feature of this linter.

Finally, I think being able to read the CodeClimate engine that reported the issue would be beneficial too. That's why it appears at the beginning of each enqueued issue, with the check inside brackets. I've been digging into the CodeClimate sources and have seen only two severities so far: `major` (which maps to `Error`) and `minor` (which maps to `Warning`). Linter v2 only sets the severity, so I've dropped the `type` message option. 

I've used the [CodeClimate data types spec for Issues](https://github.com/codeclimate/spec/blob/master/SPEC.md) and the [linter v2 spec for messages](http://steelbrain.me/linter/types/linter-message-v2.html).

So, resuming, this PR does the following:

1. Removes duplicated issues based on their fingerprints, so the errors/warnings from the console are gone and the linter badges counts are correct now.
2. Tags issues by severity, not type.
3. Shows the CodeClimate engine that reports the issue along with the check name.
4. Inserts a link to perform a google search on the reported issue if user needs thorough info.
6. Provide a long description of the issue reported as appears in the web reports.
5. Switches `linter-codeclimate` to linter v2.

Here's a screenshot that shows the final appearance:

![captura de pantalla de 2017-04-19 18-13-13](https://cloud.githubusercontent.com/assets/10707639/25190595/ffbce7e4-252c-11e7-98b7-bb105a9aefc9.png)

