### PR TITLE
Let CodeClimate decide which engines to run

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,24 +2,7 @@
 
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
-import FS from 'fs';
 import { dirname } from 'path';
-import YAML from 'js-yaml';
-
-const getEngineArgs = engineNames => engineNames
-  .reduce((prev, el) => `${prev} -e ${el}`, '').split(' ').filter(i => i);
-
-const getEnabledEngines = (configFilePath) => {
-  const configYaml = YAML.safeLoad(FS.readFileSync(configFilePath, 'utf8'));
-  const result = new Set();
-  Object.keys(configYaml.engines).forEach((engineKey) => {
-    const engine = configYaml.engines[engineKey];
-    if (engine.enabled === true) {
-      result.add(engineKey);
-    }
-  });
-  return result;
-};
 
 const badCommands = new Set();
 
@@ -121,24 +104,6 @@ export default {
   provideLinter() {
     const Helpers = require('atom-linter');
     const configurationFile = '.codeclimate.yml';
-    const linterMap = {
-      '*': ['fixme'],
-      Ruby: ['rubocop', 'reek', 'flog'],
-      'Ruby on Rails': ['rubocop', 'reek', 'flog'],
-      'Ruby on Rails (RJS)': ['rubocop', 'reek', 'flog'],
-      JavaScript: ['eslint', 'nodesecurity', 'requiresafe'],
-      CoffeeScript: ['coffeelint'],
-      'CoffeeScript (Literate)': ['coffeelint'],
-      Python: ['pep8', 'radon'],
-      PHP: ['phpcodesniffer', 'phpmd', 'phan'],
-      Go: ['gofmt', 'golint', 'govet'],
-      'GitHub Markdown': ['markdownlint', 'proselint'],
-      CSS: ['csslint', 'stylelint'],
-      Less: ['stylelint'],
-      Sass: ['scss-lint', 'stylelint'],
-      SCSS: ['scss-lint', 'stylelint'],
-      'Shell Script': ['shellcheck'],
-    };
     return {
       name: 'Code Climate',
       grammarScopes: ['*'],
@@ -146,10 +111,6 @@ export default {
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
         const fileDir = dirname(filePath);
-        const grammarName = textEditor.getGrammar().name;
-        const linterNames = new Set();
-        // Add the generic 'fixme' linter
-        linterNames.add(linterMap['*'][0]);
 
         // Search for a .codeclimate.yml in the project tree. If one isn't found,
         // use the presence of a .git directory as the assumed project root,
@@ -192,24 +153,9 @@ export default {
           return [];
         }
 
-        // Construct the list of linters to be passed to the CLI by looking at
-        // the linters made available for our language grammar by the LinterMap,
-        // and whether or not the engines are enabled in a user's config file.
-        if (Object.prototype.hasOwnProperty.call(linterMap, grammarName) === true) {
-          // for (const linter of linterMap[grammarName]) {
-          linterMap[grammarName].forEach((linter) => {
-            linterNames.add(linter);
-          });
-        }
-        const configEnabledEngines = getEnabledEngines(configurationFilePath);
-        const linterEnabledEngines = Array.from(linterNames).filter(
-          linterName => configEnabledEngines.has(linterName));
-
         // Construct the command line invocation which runs the Code Climate CLI
         const relpath = atom.project.relativizePath(filePath).pop();
-        const execArgs = ['analyze', '-f', 'json'].concat(
-          getEngineArgs(linterEnabledEngines),
-          [relpath, '</dev/null']);
+        const execArgs = ['analyze', '-f', 'json', relpath];
         const execOpts = {
           cwd: dirname(configurationFilePath),
           uniqueKey: `linter-codeclimate::${relpath}`,

--- a/lib/index.js
+++ b/lib/index.js
@@ -266,7 +266,7 @@ export default {
               colStart = (issue.location.positions.begin.column - 1) || 0;
               if (issue.location.positions.end.column !== undefined) {
                 // Valid end column, attempt to generate full range
-                colEnd = issue.location.positions.begin.column - 1;
+                colEnd = issue.location.positions.end.column - 1;
               }
               if (colEnd !== undefined && colStart !== colEnd) {
                 // Valid end column, and it isn't the same as the start

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^10.0.0",
-    "js-yaml": "^3.5.3",
-    "fs-plus": "^3.0.0"
+    "atom-linter": "^10.0.0"
   },
   "providedServices": {
     "linter": {

--- a/spec/linter-codeclimate-spec.js
+++ b/spec/linter-codeclimate-spec.js
@@ -4,6 +4,7 @@ import { join } from 'path';
 
 const fixturesPath = join(__dirname, 'fixtures');
 const coolCodePath = join(fixturesPath, 'cool_code.rb');
+const TIMEOUT = process.env.CI ? 60000 : 10000;
 
 describe('The codeclimate provider for Linter', () => {
   const lint = require('../lib/index.js').provideLinter().lint;
@@ -20,7 +21,7 @@ describe('The codeclimate provider for Linter', () => {
 
   it('works with a valid .codeclimate.yml file', () =>
     waitsForPromise(
-      { timeout: 10000 },
+      { timeout: TIMEOUT },
       () =>
       atom.workspace.open(coolCodePath).then(editor => lint(editor)).then(
         (messages) => {

--- a/spec/linter-codeclimate-spec.js
+++ b/spec/linter-codeclimate-spec.js
@@ -13,14 +13,15 @@ describe('The codeclimate provider for Linter', () => {
 
     waitsForPromise(() =>
       Promise.all([
-        atom.packages.activatePackage('language-ruby'),
         atom.packages.activatePackage('linter-codeclimate'),
       ]),
     );
   });
 
   it('works with a valid .codeclimate.yml file', () =>
-    waitsForPromise(() =>
+    waitsForPromise(
+      { timeout: 10000 },
+      () =>
       atom.workspace.open(coolCodePath).then(editor => lint(editor)).then(
         (messages) => {
           expect(messages[0].type).toBe('Warning');


### PR DESCRIPTION
This PR removes hardcoded engines and instead lets CC decide which engines to run. This closer matches default CC CLI behaviour.

As a side effect this eliminates a few dependencies as it's not needed to find and parse CC config.

Bonus: fixed end column for issue ranges.