### PR TITLE
Remove `codeclimate init`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ export default {
         const relpath = atom.project.relativizePath(filePath).pop();
         const execArgs = ['analyze', '-f', 'json', relpath];
         const execOpts = {
-          cwd: cwd,
+          cwd,
           uniqueKey: `linter-codeclimate::${relpath}`,
         };
         if (this.disableTimeout) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,10 +103,6 @@ export default {
         (value) => { this.executablePath = value; },
       ),
       atom.config.observe(
-        'linter-codeclimate.init',
-        (value) => { this.init = value; },
-      ),
-      atom.config.observe(
         'linter-codeclimate.disableTimeout',
         (value) => { this.disableTimeout = value; },
       ),
@@ -131,54 +127,28 @@ export default {
         const filePath = textEditor.getPath();
         const fileDir = dirname(filePath);
 
+        let cwd;
         // Search for a .codeclimate.yml in the project tree. If one isn't found,
-        // use the presence of a .git directory as the assumed project root,
-        // and offer to create a .codeclimate.yml file there. If the user doesn't
-        // want one, and says no, we won't bug them again.
+        // use the presence of a .git directory as the assumed project root
         const configurationFilePath = await Helpers.findAsync(fileDir, configurationFile);
         if (configurationFilePath === null) {
           const gitPath = await Helpers.findAsync(fileDir, '.git');
-          let gitDir;
           if (gitPath !== null) {
-            gitDir = dirname(gitPath);
+            cwd = dirname(gitPath);
           } else {
             // Fall back to the directory of the current file if a .git repo
             // can't be found.
-            gitDir = dirname(filePath);
+            cwd = dirname(filePath);
           }
-
-          if (atom.config.get('linter-codeclimate.init') !== false) {
-            const message = 'No .codeclimate.yml file found. Should I ' +
-              `initialize one for you in ${gitDir}?`;
-            // eslint-disable-next-line no-alert, no-restricted-globals
-            const initRepo = confirm(message);
-            if (initRepo) {
-              try {
-                await Helpers.exec(
-                  this.executablePath,
-                  ['init'],
-                  { cwd: gitDir },
-                );
-                atom.notifications.addSuccess('init complete. Save your code ' +
-                  'again to run Code Climate analysis.');
-              } catch (e) {
-                notifyError(
-                  e, `${this.executablePath} init`,
-                  `Unable to initialize \`.codeclimate.yml\` file in \`${gitDir}\`.`,
-                );
-              }
-            } else {
-              atom.config.set('linter-codeclimate.init', false);
-            }
-          }
-          return [];
+        } else {
+          cwd = dirname(configurationFilePath);
         }
 
         // Construct the command line invocation which runs the Code Climate CLI
         const relpath = atom.project.relativizePath(filePath).pop();
         const execArgs = ['analyze', '-f', 'json', relpath];
         const execOpts = {
-          cwd: dirname(configurationFilePath),
+          cwd: cwd,
           uniqueKey: `linter-codeclimate::${relpath}`,
         };
         if (this.disableTimeout) {


### PR DESCRIPTION
This subcommand was removed. We have an open issue about it on the repo,
and the tests are currently timing out on master, which is blocking an
unrelated fix. I'm hopeful this will get the tests green.

Related to https://github.com/AtomLinter/linter-codeclimate/issues/75