### PR TITLE
Fix #76: discard non-issue messages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -228,6 +228,10 @@ export default {
         let range;
         Object.keys(messages).forEach((issueKey) => {
           const issue = messages[issueKey];
+          if (issue.type.toLowerCase() !== 'issue') {
+            return;
+          }
+
           if (Object.prototype.hasOwnProperty.call(issue.location, 'positions')) {
             const line = issue.location.positions.begin.line - 1;
             let colStart;

--- a/spec/linter-codeclimate-spec.js
+++ b/spec/linter-codeclimate-spec.js
@@ -23,18 +23,22 @@ describe('The codeclimate provider for Linter', () => {
       { timeout: TIMEOUT },
       () =>
         atom.workspace.open(coolCodePath).then(editor => lint(editor)).then((messages) => {
-          expect(messages[0].severity).toBe('warning');
-          expect(messages[0].excerpt).toBe('RUBOCOP: Unused method argument - ' +
+          const rubocopMessage = messages.find(message => message.excerpt.match(/^RUBOCOP:.*?\[Rubocop\/Lint\/UnusedMethodArgument\]$/));
+
+          expect(rubocopMessage).toBeDefined();
+
+          expect(rubocopMessage.severity).toBe('warning');
+          expect(rubocopMessage.excerpt).toBe('RUBOCOP: Unused method argument - ' +
             "`bar`. If it's necessary, use `_` or `_bar` as an argument name to " +
             "indicate that it won't be used. You can also write as `foo(*)` if " +
             "you want the method to accept any arguments but don't care about " +
             'them. [Rubocop/Lint/UnusedMethodArgument]');
-          expect(messages[0].description).toBeDefined();
-          expect(messages[0].reference).not.toBeDefined();
-          expect(messages[0].icon).not.toBeDefined();
-          expect(messages[0].solutions).not.toBeDefined();
-          expect(messages[0].location.file).toBe(coolCodePath);
-          expect(messages[0].location.position).toEqual([[1, 11], [1, 14]]);
+          expect(rubocopMessage.description).toBeDefined();
+          expect(rubocopMessage.reference).not.toBeDefined();
+          expect(rubocopMessage.icon).not.toBeDefined();
+          expect(rubocopMessage.solutions).not.toBeDefined();
+          expect(rubocopMessage.location.file).toBe(coolCodePath);
+          expect(rubocopMessage.location.position).toEqual([[1, 11], [1, 14]]);
         }),
     ));
 });


### PR DESCRIPTION
I followed @a-ali suggestion in #76 but checking type's lowercase to equal "issue" because there are cases where `type: "issue"` and others `type: "Issue"`:

```json
[
  {
    "categories": [
      "Complexity"
    ],
    "check_name": "method_lines",
    "content": {
      "body": ""
    },
    "description": "Method `long_one` has 42 lines of code (exceeds 25 allowed). Consider refactoring.",
    "fingerprint": "caa1f07ae4f68cf288328348e01a0d63",
    "location": {
      "path": "cool_code.rb",
      "lines": {
        "begin": 7,
        "end": 50
      }
    },
    "other_locations": [],
    "remediation_points": 1008000,
    "severity": "minor",
    "type": "issue", //<---------this
    "engine_name": "structure"
  },
  {
    "name": "ruby.parse.succeeded",
    "type": "measurement",
    "value": 1,
    "engine_name": "structure"
  },
  {
    "type": "Issue", //<---------this
    "check_name": "Rubocop/Layout/SpaceAfterMethodName",
    "description": "Do not put a space between a method name and the opening parenthesis.",
    "categories": [
      "Style"
    ],
    "remediation_points": 50000,
    "location": {
      "path": "cool_code.rb",
      "positions": {
        "begin": {
          "column": 10,
          "line": 2
        },
        "end": {
          "column": 11,
          "line": 2
        }
      }
    },
    "content": {
      "body": "Checks for space between a method name and a left parenthesis in defs.\n\n### Example:\n\n    # bad\n    def func (x) end\n    def method= (y) end\n\n    # good\n    def func(x) end\n    def method=(y) end"
    },
    "engine_name": "rubocop",
    "fingerprint": "7ff4a8c6c8db642eb1022838a02510d3",
    "severity": "minor"
  },
```

Also, I've to change the tests because as you can see the order of the messages is different than the expected (I think more of them are returned by codeclimate): rubocop's one is not the first one anymore.

I'm using `codeclimate` cli version `0.71.1`.