### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.6.0"
+    "atom-package-deps": "^4.6.2"
   },
   "providedServices": {
     "linter": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.11.0",
     "jasmine-fix": "^1.3.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "devDependencies": {
     "eslint": "^4.6.0",
-    "eslint-config-airbnb-base": "^12.0.0",
+    "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.7.0",
     "jasmine-fix": "^1.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "linter:2.0.0"
   ],
   "devDependencies": {
-    "eslint": "^4.6.0",
+    "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.7.0",
     "jasmine-fix": "^1.3.1"


### PR DESCRIPTION
Primarily this is fixing a `peerDependency` issue between `eslint-config-airbnb-base` and `eslint`, the other two are mainly being brought in to incorporate their bug fixes.