### PR TITLE
Prevent caching an undefined TextEditor path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -294,6 +294,16 @@ const ccLinter = {
   async cacheEditor(textEditor) {
     const path = textEditor.getPath();
 
+    if (path === undefined) {
+      // Although this could be placed after the event subscriptions to allow
+      // TextEditors to automatically get fixed, it could mean that there were
+      // multiple subscriptions for the same editor. By returning before
+      // subscribing to events on an unsaved TextEditor we avoid this, and if
+      // a lint() is called on it later once it has a path it will get cached
+      // then.
+      return;
+    }
+
     if (this.cache[path]) return;
 
     textEditor.onDidDestroy(() => delete this.cache[path]);


### PR DESCRIPTION
Don't cache TextEditor's that don't have a path yet. Although the event subscription would save them later, there is a possibility that the same TextEditor would have multiple event subscriptions in this case. Since they would be cached anyway on a lint() call once they have a path, there is no need to keep them while undefined.

Fixes #55.